### PR TITLE
Make the Teleport spells respect the TpDeny list

### DIFF
--- a/src/main/java/com/luxof/lessertp/MishapThrower.kt
+++ b/src/main/java/com/luxof/lessertp/MishapThrower.kt
@@ -2,19 +2,12 @@ package com.luxof.lessertp
 
 import at.petrak.hexcasting.api.casting.mishaps.Mishap
 
-import net.fabricmc.api.ModInitializer
-
 /* I'm too lazy to mixin into the hexcasting mishap catcher.
  * smh.
  */
 
-class MishapThrower : ModInitializer {
-    override fun onInitialize() {}
-
-    companion object {
-        @JvmStatic
-        fun throwMishap(mishap: Mishap) {
-            throw mishap
-        }
+object MishapThrower {
+    fun throwMishap(mishap: Mishap) {
+        throw mishap
     }
 }

--- a/src/main/java/com/luxof/lessertp/MishapThrowerJava.java
+++ b/src/main/java/com/luxof/lessertp/MishapThrowerJava.java
@@ -9,6 +9,6 @@ import at.petrak.hexcasting.api.casting.mishaps.Mishap;
 // So I made this just to stop it from being mad at me EVERYWHERE.
 public class MishapThrowerJava {
     public static void throwMishap(Mishap mishap) {
-        MishapThrower.throwMishap(mishap);
+        MishapThrower.INSTANCE.throwMishap(mishap);
     }
 }

--- a/src/main/java/com/luxof/lessertp/actions/LesserTPAction.java
+++ b/src/main/java/com/luxof/lessertp/actions/LesserTPAction.java
@@ -7,20 +7,24 @@ import at.petrak.hexcasting.api.casting.eval.OperationResult;
 import at.petrak.hexcasting.api.casting.eval.vm.CastingImage;
 import at.petrak.hexcasting.api.casting.eval.vm.SpellContinuation;
 import at.petrak.hexcasting.api.casting.iota.Iota;
+import at.petrak.hexcasting.api.casting.mishaps.MishapBadLocation;
 import at.petrak.hexcasting.api.casting.mishaps.MishapEntityTooFarAway;
 import at.petrak.hexcasting.api.casting.OperatorUtils;
 import at.petrak.hexcasting.api.casting.RenderedSpell;
 import at.petrak.hexcasting.api.misc.MediaConstants;
+import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.common.casting.actions.spells.great.OpTeleport;
 
 import com.luxof.lessertp.MishapThrowerJava;
 
 import com.mojang.datafixers.util.Either;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
 public class LesserTPAction implements SpellAction {
@@ -52,6 +56,9 @@ public class LesserTPAction implements SpellAction {
                 clamp(vec.z, 0.001, 0.999)
             );
         }
+
+        if(HexConfig.server().canTeleportInThisDimension(ctx.getWorld().getRegistryKey()))
+            MishapThrowerJava.throwMishap(new MishapBadLocation(fract.add(teleportee.getPos().floorAlongAxes(EnumSet.allOf(Direction.Axis.class))), "bad_dimension"));
 
 		return new SpellAction.Result(
             new Spell(teleportee, fract),

--- a/src/main/java/com/luxof/lessertp/actions/LesserTPAction.java
+++ b/src/main/java/com/luxof/lessertp/actions/LesserTPAction.java
@@ -58,7 +58,7 @@ public class LesserTPAction implements SpellAction {
         }
 
         if(HexConfig.server().canTeleportInThisDimension(ctx.getWorld().getRegistryKey()))
-            MishapThrowerJava.throwMishap(new MishapBadLocation(fract.add(teleportee.getPos().floorAlongAxes(EnumSet.allOf(Direction.Axis.class))), "bad_dimension"));
+            MishapThrowerJava.throwMishap(new MishapBadLocation(fract, "bad_dimension"));
 
 		return new SpellAction.Result(
             new Spell(teleportee, fract),
@@ -68,7 +68,7 @@ public class LesserTPAction implements SpellAction {
         );
     }
 
-    public class Spell implements RenderedSpell {
+    public static class Spell implements RenderedSpell {
         private final Entity teleportee;
         private final Vec3d fract;
 

--- a/src/main/java/com/luxof/lessertp/actions/SimplerTPAction.java
+++ b/src/main/java/com/luxof/lessertp/actions/SimplerTPAction.java
@@ -12,14 +12,18 @@ import at.petrak.hexcasting.api.casting.mishaps.MishapBadLocation;
 import at.petrak.hexcasting.api.misc.MediaConstants;
 import at.petrak.hexcasting.api.casting.OperatorUtils;
 import at.petrak.hexcasting.api.casting.RenderedSpell;
+import at.petrak.hexcasting.api.mod.HexConfig;
 import at.petrak.hexcasting.common.casting.actions.spells.great.OpTeleport;
 
+import com.luxof.lessertp.MishapThrower;
 import com.luxof.lessertp.MishapThrowerJava;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
 public class SimplerTPAction implements SpellAction {
@@ -42,6 +46,9 @@ public class SimplerTPAction implements SpellAction {
             posAfterTeleport,
             10
         )) { MishapThrowerJava.throwMishap(new MishapBadLocation(posAfterTeleport, "too_far")); }
+
+        if(HexConfig.server().canTeleportInThisDimension(ctx.getWorld().getRegistryKey()))
+            MishapThrowerJava.throwMishap(new MishapBadLocation(posAfterTeleport, "bad_dimension"));
 
 		return new SpellAction.Result(
             new Spell(teleportee, offset),

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,11 +15,7 @@
 	"environment": "*",
 	"entrypoints": {
 		"main": [
-			"com.luxof.lessertp.LesserTeleport",
-			{
-				"adapter": "kotlin",
-				"value": "com.luxof.lessertp.MishapThrower"
-			}
+			"com.luxof.lessertp.LesserTeleport"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
Force LesserTP and SimpleTP to mishap when the current dimension disallows teleport spells, alongside a bit of kotlin cleanup